### PR TITLE
fix crash when adding items to the end of vector

### DIFF
--- a/cmd_sing.cpp
+++ b/cmd_sing.cpp
@@ -153,9 +153,11 @@ retry:;
             --level;
             std::vector<VskSingItem> sub(items.begin() + k + 1, items.begin() + i);
             items.erase(items.begin() + n, items.begin() + i + 1);
-            for (int m = 0; m < repeat; ++m) {
-                items.insert(items.begin() + k - 1, sub.begin(), sub.end());
-            }
+			for (int m = 0; m < repeat; ++m) {
+				auto insert_position = k - 1 <= items.size() ?
+					items.begin() + (k - 1) : items.end();
+				items.insert(insert_position, sub.begin(), sub.end());
+			}
             goto retry; // ‚P‚Â“WŠJ‚µ‚½‚çÅ‰‚©‚ç‚â‚è’¼‚·
         }
     }


### PR DESCRIPTION
Program crashes on input like `CRP2[D]` where index goes out of bound. Check boundary before operating on iterator.