### PR TITLE
special actions implementation

### DIFF
--- a/cmd_sing.cpp
+++ b/cmd_sing.cpp
@@ -115,8 +115,13 @@ bool vsk_phrase_from_sing_items(std::shared_ptr<VskPhrase> phrase, const std::ve
             phrase->add_note(ch, item.m_dot, length, item.m_sign);
             continue;
         case 'X':
-            // 画面表示
-            break;
+            // スペシャルアクション
+            if (auto ast = vsk_get_sing_param(item)) {
+                int action_no = ast->to_int();
+                phrase->add_action_node(ch, action_no);
+                continue;
+            }
+            return false;
         }
     }
     return true;

--- a/fmgon/soundplayer.cpp
+++ b/fmgon/soundplayer.cpp
@@ -234,6 +234,10 @@ void VskPhrase::destroy() {
     }
 } // VskPhrase::destroy
 
+void VskPhrase::schedule_special_action(float gate, int action_no) {
+    m_gate_to_special_action_no.push_back(std::make_pair(gate, action_no));
+}
+
 void VskPhrase::rescan_notes() {
     std::vector<VskNote> new_notes;
     for (size_t i = 0; i < m_notes.size(); ++i) {
@@ -357,7 +361,7 @@ void VskPhrase::realize(VskSoundPlayer *player) {
 
         for (auto& note : m_notes) {
             if (note.m_key == KEY_SPECIAL_ACTION) {
-                player->schedule_special_action(note.m_gate, note.m_action_no);
+                schedule_special_action(note.m_gate, note.m_action_no);
                 continue;
             }
 
@@ -560,11 +564,6 @@ void VskSoundPlayer::do_special_action(int action_no)
         (*fn)(action_no);
     else
         std::printf("special action %d\n", action_no);
-}
-
-void VskSoundPlayer::schedule_special_action(float gate, int action_no)
-{
-    m_gate_to_special_action_no.push_back(std::make_pair(gate, action_no));
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/fmgon/soundplayer.cpp
+++ b/fmgon/soundplayer.cpp
@@ -357,7 +357,7 @@ void VskPhrase::realize(VskSoundPlayer *player) {
 
         for (auto& note : m_notes) {
             if (note.m_key == KEY_SPECIAL_ACTION) {
-				player->schedule_special_action(note.m_gate, note.m_action_no);
+                player->schedule_special_action(note.m_gate, note.m_action_no);
                 continue;
             }
 
@@ -564,7 +564,7 @@ void VskSoundPlayer::do_special_action(int action_no)
 
 void VskSoundPlayer::schedule_special_action(float gate, int action_no)
 {
-	m_gate_to_special_action_no.push_back(std::make_pair(gate, action_no));
+    m_gate_to_special_action_no.push_back(std::make_pair(gate, action_no));
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/fmgon/soundplayer.h
+++ b/fmgon/soundplayer.h
@@ -131,6 +131,7 @@ struct VskPhrase {
 
     VskSoundPlayer*                     m_player;
     std::vector<std::pair<float, int>>  m_gate_to_special_action_no;
+    int                                 m_remaining_actions;
 
     VskPhrase() { }
     VskPhrase(const VskSoundSetting& setting) : m_setting(setting) { }

--- a/fmgon/soundplayer.h
+++ b/fmgon/soundplayer.h
@@ -40,7 +40,7 @@
 
 enum SpecialKeys {
     KEY_REST = -1,          // 休符のキー
-	KEY_SPECIAL_ACTION = -2 // スペシャルアクションのキー
+    KEY_SPECIAL_ACTION = -2 // スペシャルアクションのキー
 };
 
 struct VskNote {
@@ -74,7 +74,7 @@ struct VskNote {
         m_volume = volume;
         m_quantity = quantity;
         m_and = and_;
-		m_action_no = action_no;
+        m_action_no = action_no;
     }
 
     float get_sec(int tempo, float length) const;
@@ -168,10 +168,10 @@ struct VskPhrase {
     }
     void add_action_node(char note, int action_no)
 	{
-		m_notes.emplace_back(
-			m_setting.m_tempo, m_setting.m_octave,
-			m_setting.m_tone, note, false, 0, 0, m_setting.m_volume,
-			m_setting.m_quantity, false, action_no);
+        m_notes.emplace_back(
+            m_setting.m_tempo, m_setting.m_octave,
+            m_setting.m_tone, note, false, 0, 0, m_setting.m_volume,
+            m_setting.m_quantity, false, action_no);
 	}
     void add_key(int key) {
         add_key(key, false);
@@ -226,7 +226,7 @@ struct VskSoundPlayer {
     std::unordered_map<int, VskScoreBlock>      m_async_sound_map;
     static int                                  m_next_async_sound_id;
     std::unordered_map<int, VskSpecialActionFn> m_action_no_to_special_action;
-	std::vector<std::pair<float, int>>          m_gate_to_special_action_no;
+    std::vector<std::pair<float, int>>          m_gate_to_special_action_no;
 
     VskSoundPlayer() : m_playing_music(false),
                        m_stopping_event(false, false) { init_beep(); }
@@ -247,7 +247,7 @@ struct VskSoundPlayer {
     void register_special_action(int action_no, VskSpecialActionFn fn = nullptr);
     void do_special_action(int action_no);
 
-	void schedule_special_action(float gate, int action_no);
+    void schedule_special_action(float gate, int action_no);
 
 protected:
     ALuint  m_beep_buffer;

--- a/fmgon/soundplayer.h
+++ b/fmgon/soundplayer.h
@@ -123,11 +123,12 @@ struct VskSoundSetting {
 struct VskSoundPlayer;
 
 struct VskPhrase {
-    float                           m_goal = 0;
-    ALuint                          m_buffer = -1;
-    ALuint                          m_source = -1;
-    VskSoundSetting                 m_setting;
-    std::vector<VskNote>            m_notes;
+    float                               m_goal = 0;
+    ALuint                              m_buffer = -1;
+    ALuint                              m_source = -1;
+    VskSoundSetting                     m_setting;
+    std::vector<VskNote>                m_notes;
+    std::vector<std::pair<float, int>>  m_gate_to_special_action_no;
 
     VskPhrase() { }
     VskPhrase(const VskSoundSetting& setting) : m_setting(setting) { }
@@ -200,6 +201,8 @@ struct VskPhrase {
         m_notes.push_back(note);
     }
 
+    void schedule_special_action(float gate, int action_no);
+
     void rescan_notes();
     void calc_total();
     void realize(VskSoundPlayer *player);
@@ -226,7 +229,6 @@ struct VskSoundPlayer {
     std::unordered_map<int, VskScoreBlock>      m_async_sound_map;
     static int                                  m_next_async_sound_id;
     std::unordered_map<int, VskSpecialActionFn> m_action_no_to_special_action;
-    std::vector<std::pair<float, int>>          m_gate_to_special_action_no;
 
     VskSoundPlayer() : m_playing_music(false),
                        m_stopping_event(false, false) { init_beep(); }
@@ -246,8 +248,6 @@ struct VskSoundPlayer {
 
     void register_special_action(int action_no, VskSpecialActionFn fn = nullptr);
     void do_special_action(int action_no);
-
-    void schedule_special_action(float gate, int action_no);
 
 protected:
     ALuint  m_beep_buffer;

--- a/fmgon/soundplayer.h
+++ b/fmgon/soundplayer.h
@@ -128,6 +128,8 @@ struct VskPhrase {
     ALuint                              m_source = -1;
     VskSoundSetting                     m_setting;
     std::vector<VskNote>                m_notes;
+
+    VskSoundPlayer*                     m_player;
     std::vector<std::pair<float, int>>  m_gate_to_special_action_no;
 
     VskPhrase() { }
@@ -202,6 +204,7 @@ struct VskPhrase {
     }
 
     void schedule_special_action(float gate, int action_no);
+    void execute_special_actions();
 
     void rescan_notes();
     void calc_total();


### PR DESCRIPTION
This is to add support for special action execution with "X" command.

For example, running `cmd_sing X0CDEX1` will execute special action associated with `X0` before playing `CDE`, then execute special action associated with `X1`.