### PR TITLE
fix bug where last note after a digit is thrown away

### DIFF
--- a/cmd_sing.cpp
+++ b/cmd_sing.cpp
@@ -271,12 +271,10 @@ bool vsk_sing_items_from_string(std::vector<VskSingItem>& items, const VskString
                 while (!scanner.eof()) {
                     ch = scanner.getch();
                     if (!vsk_isdigit(ch)) {
+                        scanner.ungetch();
                         break;
                     }
                     item.m_param.push_back(ch);
-                }
-                if (!scanner.eof()) {
-                    scanner.ungetch();
                 }
             }
         }


### PR DESCRIPTION
Let's take a look at the input `L4C`. After `C` has been read,  since it is not a digit so the `while` loop will break. Meanwhile `scanner.eof()` is true, so `C` will not be put back to the scanner. As a result `C` is thrown away and will not be played.