### PR TITLE
Special actions implementation

### DIFF
--- a/cmd_sing.cpp
+++ b/cmd_sing.cpp
@@ -115,8 +115,13 @@ bool vsk_phrase_from_sing_items(std::shared_ptr<VskPhrase> phrase, const std::ve
             phrase->add_note(ch, item.m_dot, length, item.m_sign);
             continue;
         case 'X':
-            // 画面表示
-            break;
+            // スペシャルアクション
+            if (auto ast = vsk_get_sing_param(item)) {
+                int action_no = ast->to_int();
+                phrase->add_action_node(ch, action_no);
+                continue;
+            }
+            return false;
         }
     }
     return true;

--- a/fmgon/soundplayer.cpp
+++ b/fmgon/soundplayer.cpp
@@ -245,6 +245,11 @@ void VskPhrase::execute_special_actions() {
     // 入力が"CDX0X1"などで再生完了後にスペシャルアクションを実行する延長時間の調整に使用される
     m_remaining_actions = m_gate_to_special_action_no.size();
 
+    // アクションがない場合は何もしない
+    if (m_remaining_actions == 0) {
+        return;
+    }
+
     // gateに合わせてスペシャルアクションを実行するための制御スレッド
     unboost::thread(
         [this](int dummy) {

--- a/fmgon/soundplayer.cpp
+++ b/fmgon/soundplayer.cpp
@@ -234,6 +234,10 @@ void VskPhrase::destroy() {
     }
 } // VskPhrase::destroy
 
+void VskPhrase::schedule_special_action(float gate, int action_no) {
+    m_gate_to_special_action_no.push_back(std::make_pair(gate, action_no));
+}
+
 void VskPhrase::rescan_notes() {
     std::vector<VskNote> new_notes;
     for (size_t i = 0; i < m_notes.size(); ++i) {
@@ -357,7 +361,7 @@ void VskPhrase::realize(VskSoundPlayer *player) {
 
         for (auto& note : m_notes) {
             if (note.m_key == KEY_SPECIAL_ACTION) {
-                player->schedule_special_action(note.m_gate, note.m_action_no);
+                schedule_special_action(note.m_gate, note.m_action_no);
                 continue;
             }
 
@@ -560,11 +564,6 @@ void VskSoundPlayer::do_special_action(int action_no)
         (*fn)(action_no);
     else
         std::printf("special action %d\n", action_no);
-}
-
-void VskSoundPlayer::schedule_special_action(float gate, int action_no)
-{
-    m_gate_to_special_action_no.push_back(std::make_pair(gate, action_no));
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/fmgon/soundplayer.cpp
+++ b/fmgon/soundplayer.cpp
@@ -241,29 +241,39 @@ void VskPhrase::schedule_special_action(float gate, int action_no) {
 void VskPhrase::execute_special_actions() {
     assert(m_player);
 
+    // c‚è‚Ì–¢Às‚ÌƒAƒNƒVƒ‡ƒ“”‚ğİ’è
+    // “ü—Í‚ª"CDX0X1"‚È‚Ç‚ÅÄ¶Š®—¹Œã‚ÉƒXƒyƒVƒƒƒ‹ƒAƒNƒVƒ‡ƒ“‚ğÀs‚·‚é‰„’·ŠÔ‚Ì’²®‚Ég—p‚³‚ê‚é
     m_remaining_actions = int(m_gate_to_special_action_no.size());
 
+    // gate‚É‡‚í‚¹‚ÄƒXƒyƒVƒƒƒ‹ƒAƒNƒVƒ‡ƒ“‚ğÀs‚·‚é‚½‚ß‚Ì§ŒäƒXƒŒƒbƒh
     unboost::thread(
         [this](int dummy) {
-            // å‰å›å®Ÿè¡Œã—ãŸã‚¹ãƒšã‚·ãƒ£ãƒ«ã‚¢ã‚¯ã‚·ãƒ§ãƒ³ã®gateã‚’ä¿æŒã€åˆæœŸå€¤ã¯0
+            // ‘O‰ñÀs‚µ‚½ƒXƒyƒVƒƒƒ‹ƒAƒNƒVƒ‡ƒ“‚Ìgate‚ğ•ÛA‰Šú’l‚Í0
+            // gateAlast_gate‚Í•b‚ğ¬”“_‚Å•\‚µ‚Ä‚¢‚Ü‚·
             float last_gate = 0;
 
+            // ƒXƒyƒVƒƒƒ‹ƒAƒNƒVƒ‡ƒ“‚Ìgate‚Æaction_no‚ğvector‚©‚çæ‚èo‚µ‚ÄÀs
+            // ‡”Ô’Ê‚è‚Åvector‚É’Ç‰Á‚µ‚½‚½‚ßA‡”Ô‚Í•ÛØ‚³‚ê‚Ä‚¢‚é
+            // “¯‚¶gate’l‚ğ‚à‚Âê‡‚à‚ ‚é
             for (auto& pair : m_gate_to_special_action_no) {
+                // gate‚Í•b‚ğ¬”“_‚Å•\‚µ‚Ä‚¢‚Ü‚·
                 auto gate = pair.first;
                 auto action_no = pair.second;
 
+                // ‘O‚Ìgate‚©‚ç‚Ì‘Ò‹@ŠÔ‚ğŒvZ‚µ‚Ä‘Ò‹@
                 if (!m_player->wait_for_stop((gate - last_gate) * 1000)) {
+                    // ‘Ò‹@’†‚Éstop‚³‚ê‚½ê‡Aƒ‹[ƒv‚ğ”²‚¯‚é
                     break;
                 }
 
-                // ã‚¹ãƒšã‚·ãƒ£ãƒ«ã‚¢ã‚¯ã‚·ãƒ§ãƒ³ã‚’åˆ¥ã®ã‚¹ãƒ¬ãƒƒãƒ‰ã§å®Ÿè¡Œ
+                // ƒXƒyƒVƒƒƒ‹ƒAƒNƒVƒ‡ƒ“‚ğ•Ê‚ÌƒXƒŒƒbƒh‚ÅÀs
                 unboost::thread(
                     [this, action_no](int dummy) {
                         m_player->do_special_action(action_no);
                     },
                     0
                 ).detach();
-                // æ®‹ã‚Šã®æœªå®Ÿè¡Œã®ã‚¢ã‚¯ã‚·ãƒ§ãƒ³æ•°ã‚’ã‚’æ¸›ã‚‰ã™
+                // c‚è‚Ì–¢Às‚ÌƒAƒNƒVƒ‡ƒ“”‚ğ‚ğŒ¸‚ç‚·
                 m_remaining_actions--;
 
                 last_gate = gate;

--- a/fmgon/soundplayer.cpp
+++ b/fmgon/soundplayer.cpp
@@ -255,15 +255,15 @@ void VskPhrase::execute_special_actions() {
                     break;
                 }
 
-                if (m_player) {
-                    unboost::thread(
-                        [this, action_no](int dummy) {
-                            m_remaining_actions--;
-                            m_player->do_special_action(action_no);
-                        },
-                        0
-                    ).detach();
-                }
+                // スペシャルアクションを別のスレッドで実行
+                unboost::thread(
+                    [this, action_no](int dummy) {
+                        m_player->do_special_action(action_no);
+                    },
+                    0
+                ).detach();
+                // 残りの未実行のアクション数をを減らす
+                m_remaining_actions--;
 
                 last_gate = gate;
             }

--- a/fmgon/soundplayer.cpp
+++ b/fmgon/soundplayer.cpp
@@ -242,54 +242,54 @@ void VskPhrase::schedule_special_action(float gate, int action_no) {
 void VskPhrase::execute_special_actions() {
     assert(m_player);
 
-    // c‚è‚Ì–¢Às‚ÌƒAƒNƒVƒ‡ƒ“”‚ğİ’è
-    // “ü—Í‚ª"CDX0X1"‚È‚Ç‚ÅÄ¶Š®—¹Œã‚ÉƒXƒyƒVƒƒƒ‹ƒAƒNƒVƒ‡ƒ“‚ğÀs‚·‚é‰„’·ŠÔ‚Ì’²®‚Ég—p‚³‚ê‚é
+    // æ®‹ã‚Šã®æœªå®Ÿè¡Œã®ã‚¢ã‚¯ã‚·ãƒ§ãƒ³æ•°ã‚’è¨­å®š
+    // å…¥åŠ›ãŒ"CDX0X1"ãªã©ã§å†ç”Ÿå®Œäº†å¾Œã«ã‚¹ãƒšã‚·ãƒ£ãƒ«ã‚¢ã‚¯ã‚·ãƒ§ãƒ³ã‚’å®Ÿè¡Œã™ã‚‹å»¶é•·æ™‚é–“ã®èª¿æ•´ã«ä½¿ç”¨ã•ã‚Œã‚‹
     m_remaining_actions = m_gate_to_special_action_no.size();
 
-    // ƒAƒNƒVƒ‡ƒ“‚ª‚È‚¢ê‡‚Í‰½‚à‚µ‚È‚¢
+    // ã‚¢ã‚¯ã‚·ãƒ§ãƒ³ãŒãªã„å ´åˆã¯ä½•ã‚‚ã—ãªã„
     if (m_remaining_actions == 0) {
         return;
     }
 
-    // gate‚É‡‚í‚¹‚ÄƒXƒyƒVƒƒƒ‹ƒAƒNƒVƒ‡ƒ“‚ğÀs‚·‚é‚½‚ß‚Ì§ŒäƒXƒŒƒbƒh
+    // gateã«åˆã‚ã›ã¦ã‚¹ãƒšã‚·ãƒ£ãƒ«ã‚¢ã‚¯ã‚·ãƒ§ãƒ³ã‚’å®Ÿè¡Œã™ã‚‹ãŸã‚ã®åˆ¶å¾¡ã‚¹ãƒ¬ãƒƒãƒ‰
     unboost::thread(
         [this](int dummy) {
-            // ‘O‰ñÀs‚µ‚½ƒXƒyƒVƒƒƒ‹ƒAƒNƒVƒ‡ƒ“‚Ìgate‚ğ•ÛA‰Šú’l‚Í0
-            // gateAlast_gate‚Í•b‚ğ¬”“_‚Å•\‚µ‚Ä‚¢‚Ü‚·
+            // å‰å›å®Ÿè¡Œã—ãŸã‚¹ãƒšã‚·ãƒ£ãƒ«ã‚¢ã‚¯ã‚·ãƒ§ãƒ³ã®gateã‚’ä¿æŒã€åˆæœŸå€¤ã¯0
+            // gateã€last_gateã¯ç§’ã‚’å°æ•°ç‚¹ã§è¡¨ã—ã¦ã„ã¾ã™
             float last_gate = 0;
 
-            // gate‚ª“¯‚¶ƒXƒyƒVƒƒƒ‹ƒAƒNƒVƒ‡ƒ“‚ğ‚Ü‚Æ‚ß‚é
+            // gateãŒåŒã˜ã‚¹ãƒšã‚·ãƒ£ãƒ«ã‚¢ã‚¯ã‚·ãƒ§ãƒ³ã‚’ã¾ã¨ã‚ã‚‹
             std::map<float, std::vector<int>> gate_to_actions;
             for (const auto& pair : m_gate_to_special_action_no) {
                 gate_to_actions[pair.first].push_back(pair.second);
             }
 
-            // ƒXƒyƒVƒƒƒ‹ƒAƒNƒVƒ‡ƒ“‚ğgate‚²‚Æ‚É‚Ü‚Æ‚ß‚ÄÀs
-            // std::map‚Ìiterator‚Íkey‚Ì¸‡‚Åiterate‚·‚é‚µA
-            // ƒAƒNƒVƒ‡ƒ“‚à‡”Ô’Ê‚è‚Åvector‚É’Ç‰Á‚µ‚½‚½‚ßA‡”Ô‚Í•ÛØ‚³‚ê‚Ä‚¢‚é
-            for (auto it = gate_to_actions.begin(); it != gate_to_actions.end(); ++it) {
-                // gate‚Í•b‚ğ¬”“_‚Å•\‚µ‚Ä‚¢‚Ü‚·
-                auto gate = it->first;
-                // gate‚ª“¯‚¶ƒXƒyƒVƒƒƒ‹ƒAƒNƒVƒ‡ƒ“‚Ìvector
-                auto action_numbers = it->second;
+            // ã‚¹ãƒšã‚·ãƒ£ãƒ«ã‚¢ã‚¯ã‚·ãƒ§ãƒ³ã‚’gateã”ã¨ã«ã¾ã¨ã‚ã¦å®Ÿè¡Œ
+            // std::mapã®iteratorã¯keyã®æ˜‡é †ã§iterateã™ã‚‹ã—ã€
+            // ã‚¢ã‚¯ã‚·ãƒ§ãƒ³ã‚‚é †ç•ªé€šã‚Šã§vectorã«è¿½åŠ ã—ãŸãŸã‚ã€é †ç•ªã¯ä¿è¨¼ã•ã‚Œã¦ã„ã‚‹
+            for (auto& pair2 : gate_to_actions) {
+                // gateï¿½Í•bï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½_ï¿½Å•\ï¿½ï¿½ï¿½Ä‚ï¿½ï¿½Ü‚ï¿½
+                auto gate = pair2.first;
+                // gateï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Xï¿½yï¿½Vï¿½ï¿½ï¿½ï¿½ï¿½Aï¿½Nï¿½Vï¿½ï¿½ï¿½ï¿½ï¿½ï¿½vector
+                auto action_numbers = pair2.second;
 
-                // ‘O‚Ìgate‚©‚ç‚Ì‘Ò‹@ŠÔ‚ğŒvZ‚µ‚Ä‘Ò‹@
+                // å‰ã®gateã‹ã‚‰ã®å¾…æ©Ÿæ™‚é–“ã‚’è¨ˆç®—ã—ã¦å¾…æ©Ÿ
                 if (!m_player->wait_for_stop((gate - last_gate) * 1000)) {
-                    // ‘Ò‹@’†‚Éstop‚³‚ê‚½ê‡Aƒ‹[ƒv‚ğ”²‚¯‚é
+                    // å¾…æ©Ÿä¸­ã«stopã•ã‚ŒãŸå ´åˆã€ãƒ«ãƒ¼ãƒ—ã‚’æŠœã‘ã‚‹
                     break;
                 }
 
-                // ƒXƒyƒVƒƒƒ‹ƒAƒNƒVƒ‡ƒ“‚ğ•Ê‚ÌƒXƒŒƒbƒh‚ÅÀs
+                // ã‚¹ãƒšã‚·ãƒ£ãƒ«ã‚¢ã‚¯ã‚·ãƒ§ãƒ³ã‚’åˆ¥ã®ã‚¹ãƒ¬ãƒƒãƒ‰ã§å®Ÿè¡Œ
                 unboost::thread(
                     [this, action_numbers](int dummy) {
-                        // gate‚ª“¯‚¶ƒXƒyƒVƒƒƒ‹ƒAƒNƒVƒ‡ƒ“‚ğƒ‹[ƒvÀs
+                        // gateãŒåŒã˜ã‚¹ãƒšã‚·ãƒ£ãƒ«ã‚¢ã‚¯ã‚·ãƒ§ãƒ³ã‚’ãƒ«ãƒ¼ãƒ—å®Ÿè¡Œ
                         for (const auto& action_no : action_numbers) {
                             m_player->do_special_action(action_no);
                         }
                     },
                     0
                 ).detach();
-                // c‚è‚Ì–¢Às‚ÌƒAƒNƒVƒ‡ƒ“”‚ğ‚ğŒ¸‚ç‚·
+                // æ®‹ã‚Šã®æœªå®Ÿè¡Œã®ã‚¢ã‚¯ã‚·ãƒ§ãƒ³æ•°ã‚’ã‚’æ¸›ã‚‰ã™
                 m_remaining_actions -= action_numbers.size();
 
                 last_gate = gate;

--- a/fmgon/soundplayer.cpp
+++ b/fmgon/soundplayer.cpp
@@ -243,7 +243,7 @@ void VskPhrase::execute_special_actions() {
 
     // 残りの未実行のアクション数を設定
     // 入力が"CDX0X1"などで再生完了後にスペシャルアクションを実行する延長時間の調整に使用される
-    m_remaining_actions = int(m_gate_to_special_action_no.size());
+    m_remaining_actions = m_gate_to_special_action_no.size();
 
     // gateに合わせてスペシャルアクションを実行するための制御スレッド
     unboost::thread(
@@ -531,7 +531,7 @@ void VskSoundPlayer::play(VskScoreBlock& block) {
 
                 auto msec = uint32_t(goal * 1000.0);
                 if (m_stopping_event.wait_for_event(msec)) {
-                    int remaining_actions;
+                    size_t remaining_actions;
                     do {
                         remaining_actions = 0;
                         for (auto& phrase : phrases) {

--- a/fmgon/soundplayer.cpp
+++ b/fmgon/soundplayer.cpp
@@ -357,7 +357,7 @@ void VskPhrase::realize(VskSoundPlayer *player) {
 
         for (auto& note : m_notes) {
             if (note.m_key == KEY_SPECIAL_ACTION) {
-				player->schedule_special_action(note.m_gate, note.m_action_no);
+                player->schedule_special_action(note.m_gate, note.m_action_no);
                 continue;
             }
 
@@ -564,7 +564,7 @@ void VskSoundPlayer::do_special_action(int action_no)
 
 void VskSoundPlayer::schedule_special_action(float gate, int action_no)
 {
-	m_gate_to_special_action_no.push_back(std::make_pair(gate, action_no));
+    m_gate_to_special_action_no.push_back(std::make_pair(gate, action_no));
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/fmgon/soundplayer.cpp
+++ b/fmgon/soundplayer.cpp
@@ -241,10 +241,10 @@ void VskPhrase::schedule_special_action(float gate, int action_no) {
 void VskPhrase::execute_special_actions() {
     assert(m_player);
 
+    m_remaining_actions = int(m_gate_to_special_action_no.size());
+
     unboost::thread(
         [this](int dummy) {
-            m_remaining_actions = int(m_gate_to_special_action_no.size());
-
             float last_gate = 0.0f;
 
             for (auto& pair : m_gate_to_special_action_no) {

--- a/fmgon/soundplayer.cpp
+++ b/fmgon/soundplayer.cpp
@@ -245,7 +245,8 @@ void VskPhrase::execute_special_actions() {
 
     unboost::thread(
         [this](int dummy) {
-            float last_gate = 0.0f;
+            // 前回実行したスペシャルアクションのgateを保持、初期値は0
+            float last_gate = 0;
 
             for (auto& pair : m_gate_to_special_action_no) {
                 auto gate = pair.first;

--- a/fmgon/soundplayer.h
+++ b/fmgon/soundplayer.h
@@ -131,6 +131,7 @@ struct VskPhrase {
 
     VskSoundPlayer*                     m_player;
     std::vector<std::pair<float, int>>  m_gate_to_special_action_no;
+    int                                 m_remaining_actions;
 
     VskPhrase() { }
     VskPhrase(const VskSoundSetting& setting) : m_setting(setting) { }

--- a/fmgon/soundplayer.h
+++ b/fmgon/soundplayer.h
@@ -40,7 +40,7 @@
 
 enum SpecialKeys {
     KEY_REST = -1,          // 休符のキー
-	KEY_SPECIAL_ACTION = -2 // スペシャルアクションのキー
+    KEY_SPECIAL_ACTION = -2 // スペシャルアクションのキー
 };
 
 struct VskNote {
@@ -74,7 +74,7 @@ struct VskNote {
         m_volume = volume;
         m_quantity = quantity;
         m_and = and_;
-		m_action_no = action_no;
+        m_action_no = action_no;
     }
 
     float get_sec(int tempo, float length) const;
@@ -168,10 +168,10 @@ struct VskPhrase {
     }
     void add_action_node(char note, int action_no)
 	{
-		m_notes.emplace_back(
-			m_setting.m_tempo, m_setting.m_octave,
-			m_setting.m_tone, note, false, 0, 0, m_setting.m_volume,
-			m_setting.m_quantity, false, action_no);
+        m_notes.emplace_back(
+            m_setting.m_tempo, m_setting.m_octave,
+            m_setting.m_tone, note, false, 0, 0, m_setting.m_volume,
+            m_setting.m_quantity, false, action_no);
 	}
     void add_key(int key) {
         add_key(key, false);
@@ -226,7 +226,7 @@ struct VskSoundPlayer {
     std::unordered_map<int, VskScoreBlock>      m_async_sound_map;
     static int                                  m_next_async_sound_id;
     std::unordered_map<int, VskSpecialActionFn> m_action_no_to_special_action;
-	std::vector<std::pair<float, int>>          m_gate_to_special_action_no;
+    std::vector<std::pair<float, int>>          m_gate_to_special_action_no;
 
     VskSoundPlayer() : m_playing_music(false),
                        m_stopping_event(false, false) { init_beep(); }
@@ -247,7 +247,7 @@ struct VskSoundPlayer {
     void register_special_action(int action_no, VskSpecialActionFn fn = nullptr);
     void do_special_action(int action_no);
 
-	void schedule_special_action(float gate, int action_no);
+    void schedule_special_action(float gate, int action_no);
 
 protected:
     ALuint  m_beep_buffer;

--- a/fmgon/soundplayer.h
+++ b/fmgon/soundplayer.h
@@ -171,7 +171,7 @@ struct VskPhrase {
             quantity, and_);
     }
     void add_action_node(char note, int action_no)
-	{
+    {
         m_notes.emplace_back(
             m_setting.m_tempo, m_setting.m_octave,
             m_setting.m_tone, note, false, 0, 0, m_setting.m_volume,

--- a/fmgon/soundplayer.h
+++ b/fmgon/soundplayer.h
@@ -176,7 +176,7 @@ struct VskPhrase {
             m_setting.m_tempo, m_setting.m_octave,
             m_setting.m_tone, note, false, 0, 0, m_setting.m_volume,
             m_setting.m_quantity, false, action_no);
-	}
+    }
     void add_key(int key) {
         add_key(key, false);
     }

--- a/fmgon/soundplayer.h
+++ b/fmgon/soundplayer.h
@@ -131,7 +131,7 @@ struct VskPhrase {
 
     VskSoundPlayer*                     m_player;
     std::vector<std::pair<float, int>>  m_gate_to_special_action_no;
-    int                                 m_remaining_actions;
+    size_t                              m_remaining_actions;
 
     VskPhrase() { }
     VskPhrase(const VskSoundSetting& setting) : m_setting(setting) { }

--- a/fmgon/soundplayer.h
+++ b/fmgon/soundplayer.h
@@ -123,11 +123,12 @@ struct VskSoundSetting {
 struct VskSoundPlayer;
 
 struct VskPhrase {
-    float                           m_goal = 0;
-    ALuint                          m_buffer = -1;
-    ALuint                          m_source = -1;
-    VskSoundSetting                 m_setting;
-    std::vector<VskNote>            m_notes;
+    float                               m_goal = 0;
+    ALuint                              m_buffer = -1;
+    ALuint                              m_source = -1;
+    VskSoundSetting                     m_setting;
+    std::vector<VskNote>                m_notes;
+    std::vector<std::pair<float, int>>  m_gate_to_special_action_no;
 
     VskPhrase() { }
     VskPhrase(const VskSoundSetting& setting) : m_setting(setting) { }
@@ -200,6 +201,8 @@ struct VskPhrase {
         m_notes.push_back(note);
     }
 
+    void schedule_special_action(float gate, int action_no);
+
     void rescan_notes();
     void calc_total();
     void realize(VskSoundPlayer *player);
@@ -226,7 +229,6 @@ struct VskSoundPlayer {
     std::unordered_map<int, VskScoreBlock>      m_async_sound_map;
     static int                                  m_next_async_sound_id;
     std::unordered_map<int, VskSpecialActionFn> m_action_no_to_special_action;
-    std::vector<std::pair<float, int>>          m_gate_to_special_action_no;
 
     VskSoundPlayer() : m_playing_music(false),
                        m_stopping_event(false, false) { init_beep(); }
@@ -246,8 +248,6 @@ struct VskSoundPlayer {
 
     void register_special_action(int action_no, VskSpecialActionFn fn = nullptr);
     void do_special_action(int action_no);
-
-    void schedule_special_action(float gate, int action_no);
 
 protected:
     ALuint  m_beep_buffer;

--- a/fmgon/soundplayer.h
+++ b/fmgon/soundplayer.h
@@ -128,6 +128,8 @@ struct VskPhrase {
     ALuint                              m_source = -1;
     VskSoundSetting                     m_setting;
     std::vector<VskNote>                m_notes;
+
+    VskSoundPlayer*                     m_player;
     std::vector<std::pair<float, int>>  m_gate_to_special_action_no;
 
     VskPhrase() { }
@@ -202,6 +204,7 @@ struct VskPhrase {
     }
 
     void schedule_special_action(float gate, int action_no);
+    void execute_special_actions();
 
     void rescan_notes();
     void calc_total();


### PR DESCRIPTION
This is to add support for special action execution with "X" command.

For example, running `cmd_sing X0CDEX1` will execute special action associated with `X0` before playing `CDE`, then execute special action associated with `X1`.